### PR TITLE
Fix for names property unavailable from ObjC

### DIFF
--- a/TGPControls/TGPCamelLabels.swift
+++ b/TGPControls/TGPCamelLabels.swift
@@ -145,7 +145,7 @@ public class TGPCamelLabels: TGPCamelLabels_INTERFACE_BUILDER {
 
     // MARK: Properties
     
-    public var names:[String] = [] { // Will dictate the number of ticks
+    @objc public var names:[String] = [] { // Will dictate the number of ticks
         didSet {
             assert(names.count > 0)
             layoutTrack()


### PR DESCRIPTION
This PR is a simple fix to make the TGPCamelLabels `names` property available to ObjC code.