### PR TITLE
Fix slider pan issue with iOS 13 and new page sheet modal presentation

### DIFF
--- a/TGPControls/TGPDiscreteSlider.swift
+++ b/TGPControls/TGPDiscreteSlider.swift
@@ -708,6 +708,13 @@ public class TGPDiscreteSlider:TGPSlider_INTERFACE_BUILDER {
         return inside
     }
 
+    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer else {
+            return false
+        }
+        return !bounds.contains(gestureRecognizer.location(in: self))
+    }
+    
     // MARK: Notifications
 
     func moveThumbToTick(tick: UInt) {


### PR DESCRIPTION
This commit fixes pan slider issue when the slider is in a view controller presented with page sheet modal presentation (default presentation).